### PR TITLE
Updates the split title when the discussion title is renamed

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -18,4 +18,5 @@ return function (Dispatcher $events) {
     $events->subscribe(Listeners\AddClientAssets::class);
     $events->subscribe(Listeners\AddSplitApi::class);
     $events->subscribe(Listeners\CreatePostWhenSplit::class);
+    $events->subscribe(Listeners\UpdateSplitTitleAfterDiscussionWasRenamed::class);
 };

--- a/src/Listeners/UpdateSplitTitleAfterDiscussionWasRenamed.php
+++ b/src/Listeners/UpdateSplitTitleAfterDiscussionWasRenamed.php
@@ -1,0 +1,49 @@
+<?php
+/*
+* This file is part of flagrow/flarum-ext-split.
+*
+* Copyright (c) Flagrow.
+*
+* http://flagrow.github.io
+*
+* For the full copyright and license information, please view the license.md
+* file that was distributed with this source code.
+*/
+
+namespace Flagrow\Split\Listeners;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Flarum\Event\DiscussionWasRenamed;
+
+use Flarum\Core\Repository\PostRepository;
+
+class UpdateSplitTitleAfterDiscussionWasRenamed {
+    /**
+     * @param Dispatcher $events
+     */
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(DiscussionWasRenamed::class, [$this, 'whenDiscussionWasRenamed']);
+    }
+
+    /**
+     * @param \Flarum\Event\DiscussionWasRenamed $event
+     */
+    public function whenDiscussionWasRenamed(DiscussionWasRenamed $event) {
+            
+        $this->posts = app(PostRepository::class);
+        $allPosts = $this->posts->
+                query()->
+                where('type',"=","discussionSplit")->
+                where('content',"like","%".$event->discussion->id."-%")->
+                take(10)->
+                get(); 
+        if(count($allPosts) == 1){
+            $thisPost = $allPosts[0];
+            $oldContent = $thisPost->getContent();
+            $oldContent['title'] = $event->discussion->title;
+            $thisPost->setContent($oldContent);
+            $thisPost->save();
+        }
+    }
+}


### PR DESCRIPTION
added a quick fix for #8 to update the split title after discussion title is changed . added all changes to one single pull request.