### PR TITLE
Stop injecting dependencies for listening to events

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -13,6 +13,7 @@
 namespace Flagrow\Split;
 
 use Flagrow\Split\Api\Controllers\SplitController;
+use Flarum\Discussion\Event\Renamed;
 use Flarum\Extend;
 use Illuminate\Contracts\Events\Dispatcher;
 
@@ -27,6 +28,6 @@ return [
     function (Dispatcher $events) {
         $events->subscribe(Listeners\AddSplitApi::class);
         $events->subscribe(Listeners\CreatePostWhenSplit::class);
-        $events->subscribe(Listeners\UpdateSplitTitleAfterDiscussionWasRenamed::class);
+        $events->listen(Renamed::class, Listeners\UpdateSplitTitleAfterDiscussionWasRenamed::class);
     },
 ];

--- a/src/Listeners/UpdateSplitTitleAfterDiscussionWasRenamed.php
+++ b/src/Listeners/UpdateSplitTitleAfterDiscussionWasRenamed.php
@@ -15,7 +15,6 @@ namespace Flagrow\Split\Listeners;
 use Flarum\Discussion\Event\Renamed;
 use Flarum\Http\UrlGenerator;
 use Flarum\Post\PostRepository;
-use Illuminate\Contracts\Events\Dispatcher;
 
 class UpdateSplitTitleAfterDiscussionWasRenamed
 {
@@ -31,17 +30,9 @@ class UpdateSplitTitleAfterDiscussionWasRenamed
     }
 
     /**
-     * @param Dispatcher $events
-     */
-    public function subscribe(Dispatcher $events)
-    {
-        $events->listen(Renamed::class, [$this, 'whenRenamed']);
-    }
-
-    /**
      * @param Renamed $event
      */
-    public function whenRenamed(Renamed $event)
+    public function handle(Renamed $event)
     {
         // get the url of the discussion that was just renamed (without slug)
         $shortUrl = $this->url->to('forum')->route('discussion', ['id' => $event->discussion->id]);


### PR DESCRIPTION
When we register listeners for events via subscribers that have dependencies, this means that their constructor dependencies will be injected (and thus instantiated) at the time of registering these subscribers.

This can cause problems when other extensions want to extend the thing you are injecting, but don't get the chance to do so because this extension already injected (and thus built) that thing once.

When using event listeners without this mechanism, they (and therefore their dependencies) will only be instantiated when the event is actually fired. That's what this PR does - it should fix a conflict with another extension that we've been having on discuss.flarum.org.

Thanks for this extension! :heart: 